### PR TITLE
[WORKFLOWS-545] Adds `save_strategy` Parameter to `NF_SYNSTAGE` Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Check out the [Quickstart](#quickstart) section for example parameter values.
 - **`outdir`**: (Optional) An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix for Nextflow Tower runs. If not provided, this will default to the parent directory of the input file.
 
 - **`save_strategy`**: (Optional) A string indicating where to stage the files within the `outdir`. Options include:
-    - `default`: Files will be staged in child folders named after the Synapse or Seven Bridges ID of the file. This is the default behavior.
-    - `simple`: Files will be staged in top level of the `outdir`.
+    - `id_folders`: Files will be staged in child folders named after the Synapse or Seven Bridges ID of the file. This is the default behavior.
+    - `flat`: Files will be staged in top level of the `outdir`.
 
 ### Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Check out the [Quickstart](#quickstart) section for example parameter values.
 
 - **`outdir`**: (Optional) An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix for Nextflow Tower runs. If not provided, this will default to the parent directory of the input file.
 
+- **`simple_stage`**: (Optional) A boolean indicating whether to stage files using a simple folder structure. If `true`, files will be staged in the `outdir`. If `false`, files will be staged in child folders named after the Synapse or Seven Bridges ID of the file. If not provided, this will default to `false`.
+
 ### Known Limitations
 
 - The only way for the workflow to download Synapse files is by listing Synapse URIs in a file. You cannot provide a list of Synapse IDs or URIs to a parameter.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ Check out the [Quickstart](#quickstart) section for example parameter values.
 
 - **`outdir`**: (Optional) An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix for Nextflow Tower runs. If not provided, this will default to the parent directory of the input file.
 
-- **`simple_stage`**: (Optional) A boolean indicating whether to stage files using a simple folder structure. If `true`, files will be staged in the `outdir`. If `false`, files will be staged in child folders named after the Synapse or Seven Bridges ID of the file. If not provided, this will default to `false`.
+- **`save_strategy`**: (Optional) A string indicating where to stage the files within the `outdir`. Options include:
+    - `default`: Files will be staged in child folders named after the Synapse or Seven Bridges ID of the file. This is the default behavior.
+    - `simple`: Files will be staged in top level of the `outdir`.
 
 ### Known Limitations
 

--- a/bin/sevenbridges_get.py
+++ b/bin/sevenbridges_get.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import sys
+
+import sevenbridges as sbg
+
+
+def get_sevenbridges_file(sbg_id: str):
+    api = sbg.Api()
+    download_file = api.files.get(sbg_id)
+    download_file.download(download_file.name)
+
+
+if __name__ == "__main__":
+    sbg_id = sys.argv[1]
+    get_sevenbridges_file(sbg_id)

--- a/bin/sevenbridges_get.py
+++ b/bin/sevenbridges_get.py
@@ -6,6 +6,11 @@ import sevenbridges as sbg
 
 
 def get_sevenbridges_file(sbg_id: str):
+    """Downloads a file from Seven Bridges.
+
+    Args:
+        sbg_id (str): The string ID of a Seven Bridges file.
+    """
     api = sbg.Api()
     download_file = api.files.get(sbg_id)
     download_file.download(download_file.name)

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -1,0 +1,18 @@
+// groovy_utils.groovy
+
+class Utils {
+    static public def get_publish_dir(params, file_id) {
+        def strategy_map = [
+            "default": { "${params.outdir_clean}/${file_id}/" },
+            "simple": { "${params.outdir_clean}/" }
+            // Add more strategies as needed: "another_strategy": { "path_for_another_strategy" }
+        ]
+
+        def strategy = strategy_map.getOrDefault(params.save_strategy, {
+            def message = "Invalid save strategy: ${params.save_strategy}"
+            throw new Exception(message)
+        })
+
+        return strategy.call()
+    }
+}

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -3,8 +3,8 @@
 class Utils {
     static public def get_publish_dir(params, file_id) {
         def strategy_map = [
-            "default": { "${params.outdir_clean}/${file_id}/" },
-            "simple": { "${params.outdir_clean}/" }
+            "id_folders": { "${params.outdir_clean}/${file_id}/" },
+            "flat": { "${params.outdir_clean}/" }
             // Add more strategies as needed: "another_strategy": { "path_for_another_strategy" }
         ]
 

--- a/modules/sevenbridges_get.nf
+++ b/modules/sevenbridges_get.nf
@@ -3,7 +3,7 @@ process SEVENBRIDGES_GET {
 
   container "quay.io/biocontainers/sevenbridges-python:2.9.1--pyhdfd78af_0"
 
-  publishDir "${params.outdir_clean}/${sbg_id}/", mode: 'copy'
+  publishDir params.simple_stage ? "${params.outdir_clean}/" : "${params.outdir_clean}/${sbg_id}/", mode: 'copy'
 
   secret 'SB_API_ENDPOINT'
   secret 'SB_AUTH_TOKEN'
@@ -19,15 +19,7 @@ process SEVENBRIDGES_GET {
 
   script:
   """
-
-  #!/usr/bin/env python3
-
-  import sevenbridges as sbg
-
-  api = sbg.Api()
-  download_file = api.files.get('${sbg_id}')
-  download_file.download(download_file.name)
-
+  sevenbridges_get.py '${sbg_id}'
   """
 
 }

--- a/modules/sevenbridges_get.nf
+++ b/modules/sevenbridges_get.nf
@@ -3,7 +3,7 @@ process SEVENBRIDGES_GET {
 
   container "quay.io/biocontainers/sevenbridges-python:2.9.1--pyhdfd78af_0"
 
-  publishDir params.simple_stage ? "${params.outdir_clean}/" : "${params.outdir_clean}/${sbg_id}/", mode: 'copy'
+  publishDir "${Utils.get_publish_dir(params, sbg_id)}", mode: 'copy'
 
   secret 'SB_API_ENDPOINT'
   secret 'SB_AUTH_TOKEN'

--- a/modules/synapse_get.nf
+++ b/modules/synapse_get.nf
@@ -1,7 +1,7 @@
 // Download files from Synapse
 process SYNAPSE_GET {
 
-  publishDir "${params.outdir_clean}/${syn_id}/", mode: 'copy'
+  publishDir params.simple_stage ? "${params.outdir_clean}/" : "${params.outdir_clean}/${syn_id}/", mode: 'copy'
 
   secret 'SYNAPSE_AUTH_TOKEN'
 

--- a/modules/synapse_get.nf
+++ b/modules/synapse_get.nf
@@ -1,7 +1,7 @@
 // Download files from Synapse
 process SYNAPSE_GET {
 
-  publishDir params.simple_stage ? "${params.outdir_clean}/" : "${params.outdir_clean}/${syn_id}/", mode: 'copy'
+  publishDir "${Utils.get_publish_dir(params, syn_id)}", mode: 'copy'
 
   secret 'SYNAPSE_AUTH_TOKEN'
 

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -14,6 +14,7 @@ workdir = "${workDir.parent}/${workDir.name}"
 params.outdir = "${workDir.scheme}://${workdir}/synstage/"
 params.outdir_clean = params.outdir.replaceAll('/$', '')
 params.input_parent_dir = input_file.parent
+params.simple_stage = false
 // Parse Synapse URIs from input file
 params.synapse_uris = (input_file.text =~ 'syn://(syn[0-9]+)').findAll()    
 // Parse SBG URIs from input file

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -14,7 +14,7 @@ workdir = "${workDir.parent}/${workDir.name}"
 params.outdir = "${workDir.scheme}://${workdir}/synstage/"
 params.outdir_clean = params.outdir.replaceAll('/$', '')
 params.input_parent_dir = input_file.parent
-params.simple_stage = false
+params.save_strategy = "default"
 // Parse Synapse URIs from input file
 params.synapse_uris = (input_file.text =~ 'syn://(syn[0-9]+)').findAll()    
 // Parse SBG URIs from input file

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -14,7 +14,7 @@ workdir = "${workDir.parent}/${workDir.name}"
 params.outdir = "${workDir.scheme}://${workdir}/synstage/"
 params.outdir_clean = params.outdir.replaceAll('/$', '')
 params.input_parent_dir = input_file.parent
-params.save_strategy = "default"
+params.save_strategy = "id_folders"
 // Parse Synapse URIs from input file
 params.synapse_uris = (input_file.text =~ 'syn://(syn[0-9]+)').findAll()    
 // Parse SBG URIs from input file


### PR DESCRIPTION
**Problem:**

Some Nextflow workflows that we may run downstream of `NF_SYNSTAGE` are not `nf-core`-compatible and may require a simpler method of staging files. Currently, `NF_SYNSTAGE` puts all staged files in child folders named after the Synapse or Seven Bridges ID of that file.

**Solution:**

Allow for the option to stage all files in the first level of the `outdir` directory instead of in individual child folders by implementing the `save_strategy` parameter and mapping `save_strategy`'s to `publishDir`'s using Groovy in `SYNAPSE_GET` and `SEVENBRIDGES_GET`.

Notes:
- The workflow still places files in child folders if no `save_strategy` parameter is passed to the workflow (`params.save_strategy` is set to `id_folders` by default).
- `SEVENBRIDGES_GET` needed to be updated to place the Python logic it contains in a separate script within the `bin/` directory for the conditional `publishDir` to work in the process.
-  The appropriate section of `README.md` was updated to reflect this new change.
- This change has been tested on Tower where `save_strategy` is [set to `flat`](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/49gwAEZujagK4l) and [not provided](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/5fviPz40dl4N1k).