### PR TITLE
Pass the already calculated MD5 checksum

### DIFF
--- a/bin/synapse_index.py
+++ b/bin/synapse_index.py
@@ -76,5 +76,6 @@ if __name__ == "__main__":
         path=file_path,
         parent_id=parent_id,
         data_file_handle_id=file_handle_id,
+        content_md5=md5_checksum,
     ).store()
     print(f"{uri},{file.id}", end="")


### PR DESCRIPTION
**Problem:**

1. There are some possible cases the code may calculate the MD5 for a File if not passed into the File class instance. Since we already have the MD5 pass it into the File to prevent any possibility of it being calculated again.

**Solution:**

1. Pass in the already calculated MD5 into the File