### PR TITLE
[IBCDPE-1161] Associate storage location to container settings

### DIFF
--- a/bin/register_bucket.py
+++ b/bin/register_bucket.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
 
 """
-Registers external S3 bucket as a Storage Location in Synapse.
+Registers external S3 bucket as a Storage Location in Synapse. This also registers the
+bucket as a storage location for the parent container without updating the default
+upload location that was already set on the container.
+
 Prints the Storage Location ID.
 """
 
 import sys
 
 import synapseclient
+from synapseclient.core.async_utils import wrap_async_to_sync
 
+from synapseclient.api.entity_services import get_upload_destination
 
 bucket = sys.argv[1]
 base_key = sys.argv[2]
+parent_id = sys.argv[3]
 
 syn = synapseclient.Synapse()
 syn.login(silent=True)
@@ -22,5 +28,42 @@ storage_location_id = syn.createStorageLocationSetting(
     bucket=bucket,
     baseKey=base_key,
 )["storageLocationId"]
+
+# Grab the current settings for the container being indexed to and add the new storage
+# location to the list of storage locations. This is necessary to ensure that the
+# current default storage location is set retained on the container.
+current_container_settings = syn.getProjectSetting(
+    project=parent_id, setting_type="upload"
+)
+
+container_storage_list_needs_update = False
+has_existing_setting = current_container_settings is not None and "locations" in current_container_settings and current_container_settings[
+    "locations"]
+
+if has_existing_setting:
+    storage_locations_for_container = current_container_settings["locations"]
+    if storage_location_id not in storage_locations_for_container:
+        storage_locations_for_container.append(storage_location_id)
+        container_storage_list_needs_update = True
+else:
+    storage_locations_for_container = []
+    upload_destination = wrap_async_to_sync(
+        coroutine=get_upload_destination(
+            entity_id=parent_id,
+            synapse_client=syn,
+        ),
+        syn=syn,
+    )
+
+    if upload_destination and "storageLocationId" in upload_destination:
+        storage_locations_for_container.append(
+            upload_destination["storageLocationId"])
+        container_storage_list_needs_update = True
+    storage_locations_for_container.append(storage_location_id)
+
+if container_storage_list_needs_update:
+    syn.setStorageLocation(
+        entity=parent_id, storage_location_id=storage_locations_for_container)
+
 
 print(storage_location_id, end="")

--- a/bin/register_bucket.py
+++ b/bin/register_bucket.py
@@ -31,14 +31,17 @@ storage_location_id = syn.createStorageLocationSetting(
 
 # Grab the current settings for the container being indexed to and add the new storage
 # location to the list of storage locations. This is necessary to ensure that the
-# current default storage location is set retained on the container.
+# current default storage location set is retained on the container.
 current_container_settings = syn.getProjectSetting(
     project=parent_id, setting_type="upload"
 )
 
 container_storage_list_needs_update = False
-has_existing_setting = current_container_settings is not None and "locations" in current_container_settings and current_container_settings[
-    "locations"]
+has_existing_setting = (
+    current_container_settings is not None
+    and "locations" in current_container_settings
+    and current_container_settings["locations"]
+)
 
 if has_existing_setting:
     storage_locations_for_container = current_container_settings["locations"]
@@ -63,7 +66,8 @@ else:
 
 if container_storage_list_needs_update:
     syn.setStorageLocation(
-        entity=parent_id, storage_location_id=storage_locations_for_container)
+        entity=parent_id, storage_location_id=storage_locations_for_container
+    )
 
 
 print(storage_location_id, end="")

--- a/modules/register_bucket.nf
+++ b/modules/register_bucket.nf
@@ -9,13 +9,14 @@ process REGISTER_BUCKET {
   val   bucket
   val   base_key
   val   ready
+  val   parent_id
 
   output:
   env storage_location_id
 
   script:
   """
-  storage_location_id=\$(register_bucket.py ${bucket} ${base_key})
+  storage_location_id=\$(register_bucket.py ${bucket} ${base_key} ${parent_id})
   """
   
 }

--- a/workflows/synindex.nf
+++ b/workflows/synindex.nf
@@ -50,7 +50,7 @@ include { SYNAPSE_INDEX } from '../modules/synapse_index.nf'
 workflow SYNINDEX {
   GET_USER_ID()
   UPDATE_OWNER(GET_USER_ID.output, s3_prefix)
-  REGISTER_BUCKET(bucket, base_key, UPDATE_OWNER.output)
+  REGISTER_BUCKET(bucket, base_key, UPDATE_OWNER.output, params.parent_id)
   LIST_OBJECTS(s3_prefix, bucket, params.filename_string)
   SYNAPSE_MIRROR(LIST_OBJECTS.output, s3_prefix, params.parent_id, publish_dir)
   ch_parent_ids = SYNAPSE_MIRROR.output 


### PR DESCRIPTION
Problem:

1. A change introduced in https://sagebionetworks.jira.com/browse/PLFM-8688 requires that all storage locations that are attached to a File entity within a project have a project setting set for the container or project where files are being indexed into. The implication of this means we cannot just create a new storage location and add the files, we also need to associate that storage location to the container where files are being index into.

Solution:

1. Associate the new storage location while maintaining the current default for the container
2. Use these APIs to accomplish the task: 

- Get the current settings for the container we're uploading into: https://rest-docs.synapse.org/rest/GET/projectSettings/projectId/type/type.html
- Use PUT/POST to update/create project settings for the container: https://rest-docs.synapse.org/rest/PUT/projectSettings.html
- Get the current default upload destination for the container - Used to maintain the current default for the container so that the index process isn't updating it unintentionally: https://rest-docs.synapse.org/rest/GET/entity/id/uploadDestination.html


Testing:

- [x] To test on Seqera platform

I verified that an S3 bucket that I gave access to the dev account worked to index files as expected into Synapse:

https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/1PpoxbGVUcwOEn

![image](https://github.com/user-attachments/assets/f4e3813d-06da-4841-bb70-f2f7f2437870)

Also that the files showed in Synapse without updating the current default storage location for the container:
![image](https://github.com/user-attachments/assets/1bbbd588-b8b2-4264-baeb-3e899bf2aadd)


- [x] Tested locally with the python script below. I verified that when I comment out the call to `setStorageLocation` that it fails with the message of `synapseclient.core.exceptions.SynapseHTTPError: 400 Client Error: The storage location 42244 is not assigned to the project syn54022402.`. I verified that with that function call that a file I have in an S3 bucket is added to the Synapse project as expected.

```

import re
import os
import synapseclient
from synapseclient.core.async_utils import wrap_async_to_sync

from synapseclient.api.entity_services import get_upload_destination
from synapseclient.models import File
from synapseclient.core.utils import md5_for_file_hex

bucket = "sc-237179673806-pp-gyqoplzmpxq7g-s3bucket-ideehbufbhij"
base_key = "/test_3"
parent_id = "syn64325987"

syn = synapseclient.Synapse()
syn.login(silent=True)

storage_location_id = syn.createStorageLocationSetting(
    storage_type="ExternalS3Storage",
    upload_type="S3",
    bucket=bucket,
    baseKey=base_key,
)["storageLocationId"]

# Grab the current settings for the container being indexed to and add the new storage
# location to the list of storage locations. This is necessary to ensure that the
# default storage location is set maintained when uploading files to Synapse.
current_container_settings = syn.getProjectSetting(
    project=parent_id, setting_type="upload"
)

container_storage_needs_update = False

if current_container_settings is not None and "locations" in current_container_settings and current_container_settings["locations"]:
    storage_locations_for_container = current_container_settings["locations"]
    print(f"1: {storage_locations_for_container}")
    if storage_location_id not in storage_locations_for_container:
        print(f"4: {storage_locations_for_container}")
        storage_locations_for_container.append(storage_location_id)
        container_storage_needs_update = True
else:
    storage_locations_for_container = []
    upload_destination = wrap_async_to_sync(
        coroutine=get_upload_destination(
            entity_id=parent_id,
            synapse_client=syn,
        ),
        syn=syn,
    )
    print(f"2: {storage_locations_for_container}")

    if upload_destination and "storageLocationId" in upload_destination:
        storage_locations_for_container.append(
            upload_destination["storageLocationId"])
        print(f"3: {storage_locations_for_container}")
        container_storage_needs_update = True
    storage_locations_for_container.append(storage_location_id)

print(f"Storage locations for {parent_id} are {storage_locations_for_container}")

if container_storage_needs_update:
    syn.setStorageLocation(
        entity=parent_id, storage_location_id=storage_locations_for_container)


print(storage_location_id, end="")


def create_file_handle(
    syn: synapseclient.Synapse,
    storage_id: str,
    uri: str,
    file_name: str,
    md5_checksum: str,
) -> str:
    """Creates an external S3 file handle.

    Arguments:
        syn: Synapse client object.
        storage_id: Storage location ID.
        uri: S3 URI of the file.
        file_name: Name of the file.
        md5_checksum: MD5 checksum.

    Returns:
        file_handle_id: File handle ID
    """
    bucket, key = re.fullmatch(r"s3://([^/]+)/(.*)", uri).groups()
    file_handle = syn.create_external_s3_file_handle(
        bucket_name=bucket,
        s3_file_key=key,
        file_path=file_name,
        storage_location_id=storage_id,
        md5=md5_checksum,
    )
    return file_handle["id"]


md5_checksum = md5_for_file_hex(filename="/home/bfauble/temp/blank.txt")
file_name = os.path.basename("/home/bfauble/temp/blank.txt")
file_handle_id = create_file_handle(
    syn=syn,
    storage_id=storage_location_id,
    uri="s3://sc-237179673806-pp-gyqoplzmpxq7g-s3bucket-ideehbufbhij/test_1/blank.txt",
    file_name="/home/bfauble/temp/blank.txt",
    md5_checksum=md5_checksum,
)
file = File(
    name=file_name,
    path="/home/bfauble/temp/blank.txt",
    parent_id=parent_id,
    data_file_handle_id=file_handle_id,
    content_md5=md5_checksum,
).store()

print(f"s3://sc-237179673806-pp-gyqoplzmpxq7g-s3bucket-ideehbufbhij/test_1/blank.txt,{file.id}")
```

The file in the container is downloadable and is at the S3 bucket location:
![image](https://github.com/user-attachments/assets/c564c4db-328f-42ca-9b02-1bc736fa059f)


The default storage location for the folder is maintained:
![image](https://github.com/user-attachments/assets/f3b6f718-e89d-45e1-9ab4-b5137b75efae)
