### PR TITLE
[DPE-1209] `NF-SYNSTAGE`: Stage Files in Child Jobs

### DIFF
--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -3,8 +3,8 @@
 class Utils {
     static public def get_publish_dir(params, file_id) {
         def strategy_map = [
-            "id_folders": { "${params.outdir_clean}/${file_id}/" },
-            "flat": { "${params.outdir_clean}/" }
+            "id_folders": { "${params.outdir_clean}/${file_id}" },
+            "flat": { "${params.outdir_clean}" }
             // Add more strategies as needed: "another_strategy": { "path_for_another_strategy" }
         ]
 

--- a/modules/sevenbridges_get.nf
+++ b/modules/sevenbridges_get.nf
@@ -1,7 +1,7 @@
 // Download files from Seven Bridges
 process SEVENBRIDGES_GET {
-
-  container "quay.io/biocontainers/sevenbridges-python:2.9.1--pyhdfd78af_0"
+  label 'sevenbridges'
+  label 'download'
 
   secret 'SB_API_ENDPOINT'
   secret 'SB_AUTH_TOKEN'

--- a/modules/sevenbridges_get.nf
+++ b/modules/sevenbridges_get.nf
@@ -3,8 +3,6 @@ process SEVENBRIDGES_GET {
 
   container "quay.io/biocontainers/sevenbridges-python:2.9.1--pyhdfd78af_0"
 
-  publishDir "${Utils.get_publish_dir(params, sbg_id)}", mode: 'copy'
-
   secret 'SB_API_ENDPOINT'
   secret 'SB_AUTH_TOKEN'
 

--- a/modules/sevenbridges_get.nf
+++ b/modules/sevenbridges_get.nf
@@ -3,6 +3,8 @@ process SEVENBRIDGES_GET {
   label 'sevenbridges'
   label 'download'
 
+  tag "$sbg_id"
+
   secret 'SB_API_ENDPOINT'
   secret 'SB_AUTH_TOKEN'
 

--- a/modules/stage_file.nf
+++ b/modules/stage_file.nf
@@ -1,0 +1,17 @@
+// Stage files to their final locations
+process STAGE_FILE {
+    debug true
+    label 'aws'
+
+    input:
+    tuple val(file_uri), val(file_id), path(file)
+
+    output:
+    tuple val(file_uri), val(file_id), val("${upload_location}/${file.name}")
+
+    script:
+    upload_location = Utils.get_publish_dir(params, file_id)
+    """
+    aws s3 cp ${file} "${upload_location}/${file.name}"
+    """
+}

--- a/modules/stage_file.nf
+++ b/modules/stage_file.nf
@@ -3,6 +3,8 @@ process STAGE_FILE {
     debug true
     label 'aws'
 
+    tag "$file_id"
+
     input:
     tuple val(file_uri), val(file_id), path(file)
 

--- a/modules/synapse_get.nf
+++ b/modules/synapse_get.nf
@@ -3,6 +3,8 @@ process SYNAPSE_GET {
   label 'synapse'
   label 'download'
 
+  tag "$syn_id"
+
   secret 'SYNAPSE_AUTH_TOKEN'
 
   input:

--- a/modules/synapse_get.nf
+++ b/modules/synapse_get.nf
@@ -1,6 +1,7 @@
 // Download files from Synapse
 process SYNAPSE_GET {
   label 'synapse'
+  label 'download'
 
   secret 'SYNAPSE_AUTH_TOKEN'
 

--- a/modules/synapse_get.nf
+++ b/modules/synapse_get.nf
@@ -2,8 +2,6 @@
 process SYNAPSE_GET {
   label 'synapse'
 
-  publishDir "${Utils.get_publish_dir(params, syn_id)}", mode: 'copy'
-
   secret 'SYNAPSE_AUTH_TOKEN'
 
   input:

--- a/modules/synapse_get.nf
+++ b/modules/synapse_get.nf
@@ -10,11 +10,11 @@ process SYNAPSE_GET {
   input:
   tuple val(syn_uri), val(syn_id)
 
-  when:
-  params.synapse_uris.size() > 0
-
   output:
   tuple val(syn_uri), val(syn_id), path("*")
+  
+  when:
+  params.synapse_uris.size() > 0
 
   script:
   """

--- a/modules/update_input.nf
+++ b/modules/update_input.nf
@@ -1,6 +1,8 @@
 // Update Synapse URIs in input file with staged locations
 process UPDATE_INPUT {
   
+  label 'aws'
+  
   publishDir "${input_file.scheme}:///${params.input_parent_dir}/synstage/",  mode: 'copy'
   publishDir "${params.outdir_clean}/${run_name}/",          mode: 'copy'
 

--- a/modules/update_input.nf
+++ b/modules/update_input.nf
@@ -1,7 +1,5 @@
 // Update Synapse URIs in input file with staged locations
 process UPDATE_INPUT {
-
-  label 'aws'
   
   publishDir "${input_file.scheme}:///${params.input_parent_dir}/synstage/",  mode: 'copy'
   publishDir "${params.outdir_clean}/${run_name}/",          mode: 'copy'

--- a/modules/update_input.nf
+++ b/modules/update_input.nf
@@ -1,7 +1,7 @@
 // Update Synapse URIs in input file with staged locations
 process UPDATE_INPUT {
 
-  label 'synapse'
+  label 'aws'
   
   publishDir "${input_file.scheme}:///${params.input_parent_dir}/synstage/",  mode: 'copy'
   publishDir "${params.outdir_clean}/${run_name}/",          mode: 'copy'

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,10 +13,8 @@ profiles {
 	conda { process.conda = "$baseDir/environment.yml" }
 	docker { docker.enabled = true }
   tower {
-    withLabel: download {
-      cpus = 4
-      memory = 16.GB
-    }
+    cpus = 2
+    memory = '16 GB'
   }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ manifest {
 profiles {
 	conda { process.conda = "$baseDir/environment.yml" }
 	docker { docker.enabled = true }
-  tower {
+  cloud {
     cpus = 2
     memory = '16 GB'
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,10 +12,6 @@ manifest {
 profiles {
 	conda { process.conda = "$baseDir/environment.yml" }
 	docker { docker.enabled = true }
-  cloud {
-    cpus = 2
-    memory = '16 GB'
-  }
 }
 
   
@@ -23,7 +19,6 @@ process {
   maxErrors     = '-1'
   maxRetries    = 3
   errorStrategy = { task.attempt <= 3 ? 'retry' : 'finish' }
-
 
   withLabel: synapse {
     container = 'sagebionetworks/synapsepythonclient:v4.2.0'
@@ -33,6 +28,10 @@ process {
   }
   withLabel: sevenbridges {
     container = 'quay.io/biocontainers/sevenbridges-python:2.11.1--pyhdfd78af_0'
+  }
+  withLabel: download {
+    cpus = 4
+    memory = '16 GB'
   }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,7 +24,7 @@ process {
     container = 'sagebionetworks/synapsepythonclient:v4.7.0'
   }
   withLabel: aws {
-    container = 'ghcr.io/sage-bionetworks-workflows/aws-cli:1.0'
+    container = 'amazon/aws-cli:2.23.13'
   }
   withLabel: sevenbridges {
     container = 'quay.io/biocontainers/sevenbridges-python:2.11.1--pyhdfd78af_0'

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,7 +21,7 @@ process {
   errorStrategy = { task.attempt <= 3 ? 'retry' : 'finish' }
 
   withLabel: synapse {
-    container = 'sagebionetworks/synapsepythonclient:v4.2.0'
+    container = 'sagebionetworks/synapsepythonclient:v4.7.0'
   }
   withLabel: aws {
     container = 'ghcr.io/sage-bionetworks-workflows/aws-cli:1.0'

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,12 +12,6 @@ manifest {
 profiles {
 	conda { process.conda = "$baseDir/environment.yml" }
 	docker { docker.enabled = true }
-  tower {
-    withLabel: download {
-      cpus = 4
-      memory = 16.GB
-    }
-  }
 }
 
 process {
@@ -28,6 +22,13 @@ process {
   cpus     = 1
   memory   = 6.GB
   time     = 24.h
+
+  if (executor == 'awsbatch') {
+    withLabel 'download' {
+      cpus = 4
+      memory = 16.GB
+    }
+  }
 
   withLabel: synapse {
     container = 'sagebionetworks/synapsepythonclient:v4.2.0'

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,6 +14,13 @@ profiles {
 	docker { docker.enabled = true }
 }
 
+if (executor == 'awsbatch') {
+  withLabel 'download' {
+    cpus = 4
+    memory = 16.GB
+  }
+}
+  
 process {
   maxErrors     = '-1'
   maxRetries    = 3
@@ -23,12 +30,6 @@ process {
   memory   = 6.GB
   time     = 24.h
 
-  if (executor == 'awsbatch') {
-    withLabel 'download' {
-      cpus = 4
-      memory = 16.GB
-    }
-  }
 
   withLabel: synapse {
     container = 'sagebionetworks/synapsepythonclient:v4.2.0'

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,10 +25,6 @@ process {
   maxErrors     = '-1'
   maxRetries    = 3
   errorStrategy = { task.attempt <= 3 ? 'retry' : 'finish' }
-  
-  cpus     = 1
-  memory   = 6.GB
-  time     = 24.h
 
 
   withLabel: synapse {

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,12 +12,18 @@ manifest {
 profiles {
 	conda { process.conda = "$baseDir/environment.yml" }
 	docker { docker.enabled = true }
+  tower {
+    withLabel: download {
+      cpus = 4
+      memory = 16.GB
+    }
+  }
 }
 
 process {
   maxErrors     = '-1'
-  maxRetries    = 5
-  errorStrategy = { task.attempt <= 5 ? 'retry' : 'finish' }
+  maxRetries    = 3
+  errorStrategy = { task.attempt <= 3 ? 'retry' : 'finish' }
   
   cpus     = 1
   memory   = 6.GB
@@ -28,6 +34,9 @@ process {
   }
   withLabel: aws {
     container = 'ghcr.io/sage-bionetworks-workflows/aws-cli:1.0'
+  }
+  withLabel: sevenbridges {
+    container = 'quay.io/biocontainers/sevenbridges-python:2.11.1--pyhdfd78af_0'
   }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,14 +12,14 @@ manifest {
 profiles {
 	conda { process.conda = "$baseDir/environment.yml" }
 	docker { docker.enabled = true }
-}
-
-if (executor == 'awsbatch') {
-  withLabel 'download' {
-    cpus = 4
-    memory = 16.GB
+  tower {
+    withLabel: download {
+      cpus = 4
+      memory = 16.GB
+    }
   }
 }
+
   
 process {
   maxErrors     = '-1'

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,7 +24,7 @@ process {
     container = 'sagebionetworks/synapsepythonclient:v4.7.0'
   }
   withLabel: aws {
-    container = 'amazon/aws-cli:2.23.13'
+    container = 'ghcr.io/sage-bionetworks-workflows/aws-cli:1.0'
   }
   withLabel: sevenbridges {
     container = 'quay.io/biocontainers/sevenbridges-python:2.11.1--pyhdfd78af_0'

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -67,8 +67,6 @@ workflow SYNSTAGE {
     .map { uri, id, file -> /-e 's|\b${uri}\b|${file}|g'/ }
     .reduce { a, b -> "${a} ${b}" }
 
-    ch_stage_sed.view()
-
     // Get Workflow Run Name for Publishing
     params.name = workflow.runName
     run_name = params.name

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -61,7 +61,7 @@ workflow SYNSTAGE {
    
     // Stage files
     ch_staged_files = STAGE_FILE(ch_all_files)
-    ch_staged_files.view()
+    
     // Convert Mixed URIs and staged locations into sed expressions
     ch_stage_sed = ch_staged_files
     .map { uri, id, file -> /-e 's|\b${uri}\b|${file}|g'/ }

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -27,6 +27,7 @@ params.sbg_uris = (input_file.text =~ 'sbg://([a-zA-Z0-9]+)').findAll()
 
 include { SYNAPSE_GET } from '../modules/synapse_get.nf'
 include { SEVENBRIDGES_GET } from '../modules/sevenbridges_get.nf'
+include { STAGE_FILE } from '../modules/stage_file.nf'
 include { UPDATE_INPUT } from '../modules/update_input.nf'
 
 /*
@@ -57,11 +58,16 @@ workflow SYNSTAGE {
 
     // Mix channels
     ch_all_files = SEVENBRIDGES_GET.output.mix(SYNAPSE_GET.output)
-
+   
+    // Stage files
+    ch_staged_files = STAGE_FILE(ch_all_files)
+    ch_staged_files.view()
     // Convert Mixed URIs and staged locations into sed expressions
-    ch_stage_sed = ch_all_files
-    .map { uri, id, file -> /-e 's|\b${uri}\b|${params.outdir_clean}\/${id}\/${file.name}|g'/ }
+    ch_stage_sed = ch_staged_files
+    .map { uri, id, file -> /-e 's|\b${uri}\b|${file}|g'/ }
     .reduce { a, b -> "${a} ${b}" }
+
+    ch_stage_sed.view()
 
     // Get Workflow Run Name for Publishing
     params.name = workflow.runName


### PR DESCRIPTION
**Problem:**

Currently, the `SYNAPSE_GET` and `SEVENBRIDGES_GET` modules use the `publishDir` directive to stage files downloaded to the locations we want them in in S3. This is the "standard" way to achieve what we are doing in Nextflow, but it has one major drawback. The work of actually copying the file from the process work directory to the selected `publishDir` is not actually done in the child job, but in the head job. What this means is that the child job downloading the files is considered by Nextflow to have completed successfully when the file is downloaded and provided as output for downstream processes. It can therefore be considered complete _before_ the file actually exists in the staged location. This is especially true in cases where we are staging large numbers (100s) of large (>1GB) files. A significant queue of files to copy can build up for the head job, even though all processes have technically completed successfully. This gives the impression that the workflow is hanging in Seqera Platform, even though work is still being done. Additionally, this queue of files to copy that only the head job handles can take a long time to get through because we are not benefitting from the parallelization of work.

**Solution:**

Break up the work of staging the files from process work directories to the staging location into child jobs. To do this, I have implemented a new process `STAGE_FILE` which takes all of the downloaded files from the `SYNAPSE_GET` and `SEVENBRIDGES_GET` processes, moves them to their staged location in S3, and provides a list of new file locations to be used for updating the input file in `UPDATE_INPUT`.

**Testing:**

- [Test](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/3nMYFRWFbFR0ie) with some larger files from Synapse.
- [Test](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2Lu2hjpTVgrBMp) with both Synapse and Seven Bridges files.
- I also used this branch to stage a large (554 ~2-6GB FASTQ files) iAtlas dataset in that workspace on SP prod. It finished in less than half the time that the old implementation took.

**Notes:**

- We are making a trade off here where the work of staging files is being broken up, but we will incur some wall time for the necessary compute resources to be provisioned for the `STAGE_FILE` process executions (especially when running on `spot` instances).
     - I considered having one process that can download files from Synapse or Seven Bridges AND stage them to their locations in one go, but opted against it because we would have needed to maintain a Python Docker container with `synapseclient`, `sevenbridges` and `aws-cli` all installed.
     - This means that we will not see much efficiency gains for small datasets being staged, but for larger datasets such as the 100s of 1+GB files example we will.
- Users will now be able to accurately track the status of their run. The run should complete when `UPDATE_INPUT` has succeeded.
- Bumped versions of `synapseclient` and `sevenbridges` being used.
- Added some new labels and tags for simplicity and tracking purposes.