### PR TITLE
Reverts `synapsepythonclient` Docker Container Version

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -21,6 +21,7 @@ process {
   errorStrategy = { task.attempt <= 3 ? 'retry' : 'finish' }
 
   withLabel: synapse {
+    // TODO: Update to ghcr.io/sage-bionetworks/synapsepythonclient:v4.8.0 once it is released
     container = 'sagebionetworks/synapsepythonclient:v4.2.0'
   }
   withLabel: aws {

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,7 +21,7 @@ process {
   errorStrategy = { task.attempt <= 3 ? 'retry' : 'finish' }
 
   withLabel: synapse {
-    container = 'sagebionetworks/synapsepythonclient:v4.7.0'
+    container = 'sagebionetworks/synapsepythonclient:v4.2.0'
   }
   withLabel: aws {
     container = 'ghcr.io/sage-bionetworks-workflows/aws-cli:1.0'


### PR DESCRIPTION
# Problem

The `sagebionetworks/synapsepythonclient:v4.7.0` Docker container doesn't properly install `pandas`, so `SYNAPSE_MIRROR` is failing.

# Solution

Revert back to `sagebionetworks/synapsepythonclient:v4.2.0`.

# Testing

Tested both [synindex](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/29Los1GCs1CLue) and [synstage](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/28yjjN37Ni89Sp) on SP.