### PR TITLE
[DPE-1240] Updates Entrypoint handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing New Workflows
 
-In order to contribute to `nf-synapse`, you will first need to either create a feature branch on the main repository (if you are a Sage Bio employee) or fork the repository and create a feature branch on your fork. Once you have a branch or fork, you can create a new workflow by following the steps below.
+In order to contribute to `nf-synapse`, you will first need to either create a feature branch on the main repository (if you are a Sage Bionetworks employee) or fork the repository. Once you have a branch or fork, you can create a new workflow by following the steps below.
 
 ## Create New Modules
 
@@ -14,33 +14,37 @@ Once you have created all of the modules necessary for your workflow, you can cr
 
 ## Add New Workflow to `main.nf`
 
-After your workflow is complete, you will need to add it to the `main.nf` file. This file provides the entrypoint for running any workflow in this repository. Follow the example set by the `NF_SYNSTAGE` workflow:
+After your workflow is complete, you will need to add it to the `main.nf` file. Follow the examples already present to provide access to your workflow given a `params.entry` value:
 1. Write a comment that describes the purpose of your workflow.
 1. Add the `include` statement to import your workflow to `main.nf`.
-1. Add your workflow to `main.nf`. Follow the naming convention of `NF_<WORKFLOW_NAME>` as shown in the example.
+1. Add your workflow to `main.nf`.
 
 Example:
 ```nextflow
 // Synstage - Stage files from Synapse to Nextflow Tower S3 Bucket
-include { SYNSTAGE } from './workflows/synstage.nf'
+include { WORKFLOW_NAME } from './workflows/workflow_name.nf'
 
-workflow NF_SYNSTAGE {
-    SYNSTAGE ()
+workflow {
+    ...
+    else if (params.entry == 'workflow_name') {
+        WORKFLOW_NAME ()
+    }
+    ...
 }
 ```
 
 ## Test Your Workflow Locally
 
-Once your workflow is added to `main.nf` with a unique name, it is now accessible to be run with the `entry` parameter. If it is possible to do so, test the workflow on your local machine using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run). It will be much easier to debug any problems you encounter locally before running on Nextflow Tower.
+Once your workflow is added to `main.nf` with a unique name, it is now accessible to be run with the `params.entry` parameter. If it is possible to do so, test the workflow on your local machine using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run). It will be much easier to debug any problems you encounter locally before running on Seqera Platform.
 Example:
 ```
-nextflow run main.nf -profile docker -entry NF_<WORKFLOW_NAME> --my_param my_param_value
+nextflow run main.nf -profile docker --entry <WORKFLOW_NAME>
 ```
 
 ## Test Your Workflow in Nextflow Tower
 
-Using the [Tower CLI](https://help.tower.nf/latest/cli/), or the [Tower Web UI](https://help.tower.nf/latest/launch/launchpad/) run your workflow and ensure that it completes successfully and with the intended results. Be sure to provide the name of your branch as the `revision`(and the URL to your fork, if applicable) to the Tower run.
+Using the [Tower CLI](https://help.tower.nf/latest/cli/), or the [Seqera Platform UI](https://help.tower.nf/latest/launch/launchpad/) run your workflow and ensure that it completes successfully and with the intended results. Be sure to provide the name of your branch as the `revision`(and the URL to your fork, if applicable) to the Tower run.
 
 ## Update The README
 
-Before submitting your pull request, update the `README.md` file to include a description of your workflow. Follow the example set by the `NF_SYNSTAGE` section and include all relavent sections.
+Before submitting your pull request, update the `README.md` file to include a description of your workflow. Follow the example set by the `SYNSTAGE` and `SYNINDEX` sections and include all relavent information.

--- a/README.md
+++ b/README.md
@@ -115,10 +115,9 @@ Note: `SYNSTAGE` can handle either or both types of URIs in a single input file.
 
 Check out the [Quickstart](#Quickstart:SYNSTAGE) section for example parameter values.
 
+- **`entry`**: (Required) The name of the workflow to run (`synstage`). This should be the name of the workflow file in the `workflows/` directory.
 - **`input`**: (Required) A text file containing Synapse URIs (_e.g._ `syn://syn28521174`). The text file can have any format (_e.g._ a single column of Synapse URIs, a CSV/TSV sample sheet for an nf-core workflow).
-
 - **`outdir`**: (Optional) An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix for Nextflow Tower runs. If not provided, this will default to the parent directory of the input file.
-
 - **`save_strategy`**: (Optional) A string indicating where to stage the files within the `outdir`. Options include:
     - `id_folders`: Files will be staged in child folders named after the Synapse or Seven Bridges ID of the file. This is the default behavior.
     - `flat`: Files will be staged in top level of the `outdir`.
@@ -175,6 +174,7 @@ The examples below demonstrate how you would index files from an S3 bucket calle
 
 Check out the [Quickstart](#Quickstart:SYNINDEX) section for example parameter values.
 
+- **`entry`**: (Required) The name of the workflow to run (`synindex`). This should be the name of the workflow file in the `workflows/` directory.
 - **`s3_prefix`**: (Required) The S3 URI of the S3 bucket that contains the files to be indexed.
 - **`parent_id`**: (Required) The Synapse ID of the Synapse project or folder that the files will be indexed into.
 - **`filename_string`**: (Optional) A string that will be matched against the names of the files in the S3 bucket. If provided, only files that contain the string will be indexed.

--- a/README.md
+++ b/README.md
@@ -4,40 +4,40 @@ A centralized repository of Nextflow workflows that interact with [Synapse](http
 
 ## Purpose
 
-The purpose of this repository is to provide a collection of Nextflow workflows that interact with Synapse by leveraging the [Synapse Python Client](https://github.com/Sage-Bionetworks/synapsePythonClient). These workflows are intended to be used in a [Nextflow Tower](https://help.tower.nf/latest/) environment primarily, but they can also be executed using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run) on your local machine.
+The purpose of this repository is to provide a collection of Nextflow workflows that interact with Synapse by leveraging the [Synapse Python Client](https://github.com/Sage-Bionetworks/synapsePythonClient). These workflows are intended to be used in a [Seqera Platform](https://docs.seqera.io/platform/latest/) environment primarily, but they can also be executed using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run) on your local machine.
 
 ## Structure
 
 This repository is organized as follows:
 1. Individual process definitions, or modules, are stored in the `modules/` directory.
 1. Modules are then combined into workflows, stored in the `workflows/` directory. These workflows are intended to capture the entire process of an interaction with Synapse.
-1. Workflows are then represented in the `main.nf` script, which provides an entrypoint for each workflow.
+1. Workflows are then imported into the `main.nf` script, and can be run only by specifying the `params.entry` parameter.
 
 ## Usage
 
-Only one workflow can be used per `nf-synapse` run. The configuration for a workflow run will need to include which workflow you intend to use (indicated by specifying `entry`), along with all of the parameters required for that workflow.
+Only one workflow can be used per `nf-synapse` run. The configuration for a workflow run will need to include which workflow you intend to use (indicated by specifying `params.entry`), along with all of the parameters required for that workflow.
 
-In the example below, we provide the `entry` parameter `NF_SYNSTAGE` to indicate that we want to run the `NF_SYNSTAGE` workflow. We also provide the `input` parameter, which is required for `NF_SYNSTAGE`.
+In the example below, we provide the `params.entry` parameter `synstage` to indicate that we want to run the `SYNSTAGE` workflow. We also provide the `input` parameter, which is required for `SYNSTAGE`.
 
 ```
-nextflow run main.nf -profile docker -entry NF_SYNSTAGE --input path/to/input.csv
+nextflow run main.nf -profile docker --entry synstage --input path/to/input.csv
 ```
 
 ## Meta-Usage
 
-`NF_SYNAPSE` is designed to be used on either side of a general-purpose Nextflow Workflow to stage input files from Synapse/SevenBridges to an S3 bucket, run a workflow of your choosing, and then index the output files from the S3 bucket back into Synapse. 
+`nf-synapse` is designed to be used on either side of a general-purpose Nextflow Workflow to stage input files from Synapse or SevenBridges to an S3 bucket, run a workflow of your choosing, and then index the output files from the S3 bucket back into Synapse. 
 
 ```mermaid
 flowchart LR;
-   A[NF_SYNAPSE:NF_SYNSTAGE]-->B[WORKFLOW];
-   B-->C[NF_SYNAPSE:NF_SYNINDEX];
+   A[nf-synapse:SYNSTAGE]-->B[WORKFLOW];
+   B-->C[nf-synapse:SYNINDEX];
 ```
 
 See [`demo.py`](https://github.com/Sage-Bionetworks-Workflows/py-orca/blob/main/demo.py) in `Sage-Bionetworks-Workflows/py-orca` for an example of accomplishing this goal with Python code.
 
 ## Authentication
 
-For Nextflow Tower runs, you can configure your secrets using the [Tower CLI](https://help.tower.nf/23.2/cli/cli/) or the [Tower Web UI](https://help.tower.nf/23.2/). If you are running the workflow locally, you can configure your secrets within the [Nextflow CLI](https://nextflow.io/docs/latest/secrets.html).
+For Seqera Platform runs, you can configure your secrets using the [Tower CLI](https://help.tower.nf/23.2/cli/cli/) or the [Seqera Platform UI](https://docs.seqera.io/platform/latest). If you are running the workflow locally, you can configure your secrets within the [Nextflow CLI](https://nextflow.io/docs/latest/secrets.html).
 
 ### Synapse
 
@@ -47,26 +47,28 @@ All included workflows require a `SYNAPSE_AUTH_TOKEN` secret. You can generate a
 
 Current `profiles` included in this repository are:
 1. `docker`: Indicates that you want to run the workflow using Docker for running process containers.
-2. `conda`: Indicates that you want to use a `conda` environment for running process containers.
+1. `conda`: Indicates that you want to use a `conda` environment for running process containers.
+1. `synstage`: Indicates that you want to run the `SYNSTAGE` workflow (sets `params.entry = 'synstage'`).
+1. `synindex`: Indicates that you want to run the `SYNINDEX` workflow (sets `params.entry = 'synindex'`).
 
 # Included Workflows
 
-## `NF_SYNSTAGE`: Stage Synapse Files To AWS S3
+## `SYNSTAGE`: Stage Synapse Files To AWS S3
 
 ### Purpose
 
-The purpose of this workflow is to automate the process of staging Synapse and SevenBridges files to a Nextflow Tower-accessible location (_e.g._ an S3 bucket). In turn, these staged files can be used as input for a general-purpose (_e.g._ nf-core) workflow that doesn't contain platform-specific steps for staging data. This workflow is intended to be run first in preparation for other data processing workflows.
+The purpose of this workflow is to automate the process of staging Synapse and SevenBridges files to a Seqera Platform-accessible location (_e.g._ an S3 bucket). In turn, these staged files can be used as input for a general-purpose (_e.g._ nf-core) workflow that doesn't contain platform-specific steps for staging data. This workflow is intended to be run first in preparation for other data processing workflows.
 
 ### Overview
 
-`NF_SYNSTAGE` performs the following steps:
+`SYNSTAGE` performs the following steps:
 
 1. Extract all Synapse and SevenBridges URIs (_e.g._ `syn://syn28521174` or `sbg://63b717559fd1ad5d228550a0`) from a given text file.
 1. Download the corresponding files from both platforms in parallel.
 1. Replace the URIs in the text file with their staged locations.
 1. Output the updated text file so it can serve as input for another workflow.
 
-### Quickstart:SYNSTAGE
+### Quickstart: SYNSTAGE
 
 The examples below demonstrate how you would stage Synapse files in an S3 bucket called `example-bucket`, but they can be adapted for other storage backends.
 
@@ -79,12 +81,12 @@ The examples below demonstrate how you would stage Synapse files in an S3 bucket
     foobar,syn://syn28521174,syn://syn28521175,unstranded
     ```
 
-1. Launch workflow using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run), the [Tower CLI](https://help.tower.nf/latest/cli/), or the [Tower web UI](https://help.tower.nf/latest/launch/launchpad/).
+1. Launch workflow using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run), the [Tower CLI](https://help.tower.nf/latest/cli/), or the [Seqera Platform UI](https://docs.seqera.io/platform/latest).
 
     **Example:** Launched using the Nextflow CLI
 
     ```console
-    nextflow run main.nf -profile docker -entry NF_SYNSTAGE --input path/to/input.csv
+    nextflow run main.nf -profile docker --entry synstage --input path/to/input.csv
     ```
 
 1. Retrieve the output file, which by default is stored in a `synstage/` subfolder within the parent directory of the input file. The Synapse and/or Seven Bridges URIs have been replaced with their staged locations. This file can now be used as the input for other workflows.
@@ -107,7 +109,7 @@ If you are staging Seven Bridges files, there are a few differences that you wil
    - The first way involves logging into a SevenBridges portal, such as [SevenBridges CGC](https://cgc-accounts.sbgenomics.com/auth/login), navigating to the file and copying the ID from the URL. For example, your URL might look like this: "https://cgc.sbgenomics.com/u/user_name/project/63b717559fd1ad5d228550a0/". From this url, you would copy the "63b717559fd1ad5d228550a0" piece and combine it with the `sbg://` prefix to have the complete URI `sbg://63b717559fd1ad5d228550a0`.
    - The second way involves using the [SBG CLI](https://docs.sevenbridges.com/docs/files-and-metadata). To get the ID numbers that you need, run the `sb files list` command and specify the project that you are downloading files from. A list of all files in the project will be returned, and you will combine the ID number with the prefix for each file that you want to stage.
 
-Note: `NF_SYNSTAGE` can handle either or both types of URIs in a single input file.
+Note: `SYNSTAGE` can handle either or both types of URIs in a single input file.
 
 ### Parameters
 
@@ -126,15 +128,15 @@ Check out the [Quickstart](#Quickstart:SYNSTAGE) section for example parameter v
 - The only way for the workflow to download Synapse files is by listing Synapse URIs in a file. You cannot provide a list of Synapse IDs or URIs to a parameter.
 - The workflow doesn't check if newer versions exist for the files associated with the Synapse URIs. If you need to force-download a newer version, you should manually delete the staged version.
 
-## `NF_SYNINDEX`: Index S3 Objects Into Synapse
+## `SYNINDEX`: Index S3 Objects Into Synapse
 
 ### Purpose
 
-The purpose of this workflow is to automate the process of indexing files in an S3 bucket into Synapse. `NF_SYNINDEX` is intended to be used after a general-purpose (_e.g._ nf-core) workflow that doesn't contain platform-specific steps for uploading/indexing data. 
+The purpose of this workflow is to parallelize the process of indexing files in an S3 bucket into Synapse. `SYNINDEX` is intended to be used after a general-purpose (_e.g._ nf-core) workflow that doesn't contain platform-specific steps for uploading/indexing data. 
 
 ### Overview
 
-`NF_SYNINDEX` performs the following steps:
+`SYNINDEX` performs the following steps:
 
 1. Gets the Synapse user ID for the account that provided the `SYNAPSE_AUTH_TOKEN` secret.
 1. Updates or creates the `owner.txt` file in the S3 bucket to make the current user an owner.
@@ -159,12 +161,12 @@ The examples below demonstrate how you would index files from an S3 bucket calle
     │   ├── test1.txt
     ```
 
-1. Launch workflow using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run), the [Tower CLI](https://help.tower.nf/latest/cli/), or the [Tower web UI](https://help.tower.nf/latest/launch/launchpad/).
+1. Launch workflow using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run), the [Tower CLI](https://help.tower.nf/latest/cli/), or the [Seqera Platform UI](https://docs.seqera.io/platform/latest).
 
     **Example:** Launched using the Nextflow CLI
 
     ```console
-    nextflow run main.nf -profile docker -entry NF_SYNINDEX --s3_prefix s3://example-bucket --parent_id syn12345678
+    nextflow run main.nf -profile docker --entry synindex --s3_prefix s3://example-bucket --parent_id syn12345678
     ```
 
 1. Retrieve the output file, which by default is stored in a `S3://example-bucket/synindex/under-syn12345678/` in our example. This folder will contain a mapping of Synapse URIs to their indexed Synapse IDs.
@@ -179,4 +181,4 @@ Check out the [Quickstart](#Quickstart:SYNINDEX) section for example parameter v
 
 ### Known Limitations
 
-At present, it is not possible for `NF_SYNINDEX` to be run outside of Nextflow Tower. This is due to AWS permissions complications. [Future work](https://sagebionetworks.jira.com/browse/IBCDPE-910) will include enabling the workflow to run on local machines/in virtual machines. 
+At present, it is not possible for `SYNINDEX` to be run outside of Nextflow Tower. This is due to AWS permissions complications. [Future work](https://sagebionetworks.jira.com/browse/IBCDPE-910) will include enabling the workflow to run on local machines/in virtual machines. 

--- a/main.nf
+++ b/main.nf
@@ -1,15 +1,26 @@
 nextflow.enable.dsl = 2
 
-// NF_SYNSTAGE - Stage files from Synapse to Nextflow Tower S3 Bucket
-include { SYNSTAGE } from './workflows/synstage.nf'
-
-workflow NF_SYNSTAGE {
-    SYNSTAGE ()
+// entry validation
+valid_entry_points = ['synstage', 'synindex']
+if (!params.entry) {
+    error "Entry point must be specified using --entry. Select one of: ${valid_entry_points.join(', ')}"
+}
+if (!valid_entry_points.contains(params.entry)) {
+    error "Invalid entry point: '${params.entry}'. Valid options are: ${valid_entry_points.join(', ')}"
 }
 
-// NF_SYNINDEX - Index files into Synapse from Nextflow Tower S3 Bucket
+// SYNSTAGE - Stage files from Synapse to Nextflow Tower S3 Bucket
+include { SYNSTAGE } from './workflows/synstage.nf'
+
+// SYNINDEX - Index files into Synapse from Nextflow Tower S3 Bucket
 include { SYNINDEX } from './workflows/synindex.nf'
 
-workflow NF_SYNINDEX {
-    SYNINDEX ()
+workflow {
+    if (params.entry == 'synstage') {
+        SYNSTAGE ()
+    } else if (params.entry == 'synindex') {
+        SYNINDEX ()
+    } else {
+        error "Invalid entry point: '${params.entry}'. Valid options are: '${valid_entry_points.join(', ')}'"
+    }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,12 @@ manifest {
 profiles {
 	conda { process.conda = "$baseDir/environment.yml" }
 	docker { docker.enabled = true }
+  synstage {
+    params.entry = 'synstage'
+  }
+  synindex {
+    params.entry = 'synindex'
+  }
 }
 
   

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -6,7 +6,7 @@ nextflow.enable.dsl = 2
     SETUP PARAMS
 ========================================================================================
 */
-// Need default file or NF_SYNINDEX cannot be run
+// Need default file or SYNINDEX cannot be run
 params.input = "${projectDir}/dummy.txt"
 input_file = file(params.input)
 workdir = "${workDir.parent}/${workDir.name}"


### PR DESCRIPTION
# **Problem:**

Recently while in conversations with Code Ocean, it was brought to my attention that Seqera has deprecated support for the entry[ CLI option ](https://www.nextflow.io/docs/latest/reference/cli.html#cli-reference)for Nextflow as of 24.10.0.

> -entry
> Deprecated since version 24.10.0: Use params in the entry workflow to call different workflows from the command line.

We currently rely on this option in both the `nf-synapse` and `nf-synapse-challenge` workflows to toggle between workflows to execute. Based on the suggestion quoted above, Seqera seems to recommend that a normal parameter be used instead. Therefore, we will need some sort of toggling logic built into the workflows that expects a parameter to be set.

# **Solution:**

Implement a simple and easy to copy method for providing an entrypoint to `params.entry` instead of the special `entry` option. I also included profiles `synstage` and `synindex` which set the `params.entry` accordingly too (in the Seqera Platform UI users can quickly select their workflow type by clicking instead of typing if they choose).

I had initially wanted to create a more robust tool that could be used to convert any of our Nextflow repositories to a multi-workflow tool without need for repeating the same if/else-type logic in more than one place, but abandoned the effort in favor of this more straightforward approach after determining that it likely wasn't worth maintaining a separate tool (a Nextflow Plugin) for this purpose. See this [ticket](https://sagebionetworks.jira.com/browse/DPE-1240) in Jira for more context.

# **Testing:**

Tested the workflow on Seqera Platform (dev) for both [synstage](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/3sWHhJPnUw6miq) and [synindex](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/4qnjZGSdoDNinR).

`README.md` and `CONTRIBUTING.md` were updated to reflect the changes introduced here.

# **Notes:**

- Before merging this PR, we will need to inform users of the change so they understand how the default behavior of this workflow will change. In order to help with the transition, I have created a release (`0.1.0`) on the current `main` branch that can be used as the `revision` for a workflow run to continue supporting the old `entry` method until our Seqera Platform deployment is upgraded to have a Nextflow version >=24.10.0.
- If possible, I'd like to be aligned as a team with regards to how this works across repositories so we should review this method with the remaining `nf-synapse-challenge` and `nf-genie` use cases in mind as well (I will tag maintainers of those tools specifically for review here).
