### PR TITLE
[DPE-695] Fix extra slashes breaking `synstage` pipeline runs

### DIFF
--- a/modules/update_owner.nf
+++ b/modules/update_owner.nf
@@ -12,13 +12,12 @@ process UPDATE_OWNER {
 
   script:
   """
-  echo $user_id | aws s3 cp - ${s3_prefix}/owner.txt
-  // ( \
-  //    ( aws s3 cp ${s3_prefix}/owner.txt - 2>/dev/null || true ); \
-  //     echo $user_id \
-  // ) \
-  // | sort -u \
-  // | aws s3 cp - ${s3_prefix}/owner.txt
+  ( \
+     ( aws s3 cp ${s3_prefix}/owner.txt - 2>/dev/null || true ); \
+      echo $user_id \
+  ) \
+  | sort -u \
+  | aws s3 cp - ${s3_prefix}/owner.txt
   """
 
 }

--- a/modules/update_owner.nf
+++ b/modules/update_owner.nf
@@ -12,12 +12,13 @@ process UPDATE_OWNER {
 
   script:
   """
-  ( \
-     ( aws s3 cp ${s3_prefix}/owner.txt - 2>/dev/null || true ); \
-      echo $user_id \
-  ) \
-  | sort -u \
-  | aws s3 cp - ${s3_prefix}/owner.txt
+  echo $user_id | aws s3 cp - ${s3_prefix}/owner.txt
+  // ( \
+  //    ( aws s3 cp ${s3_prefix}/owner.txt - 2>/dev/null || true ); \
+  //     echo $user_id \
+  // ) \
+  // | sort -u \
+  // | aws s3 cp - ${s3_prefix}/owner.txt
   """
 
 }

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -9,9 +9,16 @@ nextflow.enable.dsl = 2
 // Need default file or SYNINDEX cannot be run
 params.input = "${projectDir}/dummy.txt"
 input_file = file(params.input)
-workdir = workDir.parent ? "${workDir.parent}/${workDir.name}" : "${workDir.name}"
+workdir = "${workDir.parent}/${workDir.name}"
 params.outdir = "${workDir.scheme}://${workdir}/synstage/"
-params.outdir_clean = params.outdir.replaceAll('/$', '')
+
+// Use URI parsing to clean up redundant slashes safely from path
+uri = new URI(params.outdir)
+// Remove leading slash, duplicate slashes, and trailing slash, in that order!
+normalized_path = uri.path.replaceAll('^/', '').replaceAll('/+', '/').replaceAll('/$', '')
+// Compose the final cleaned up outdir
+params.outdir_clean = "${uri.scheme}://${normalized_path}"
+
 params.input_parent_dir = input_file.parent
 params.save_strategy = "id_folders"
 // Parse Synapse URIs from input file

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -9,7 +9,7 @@ nextflow.enable.dsl = 2
 // Need default file or SYNINDEX cannot be run
 params.input = "${projectDir}/dummy.txt"
 input_file = file(params.input)
-workdir = "${workDir.parent}/${workDir.name}"
+workdir = workDir.parent ? "${workDir.parent}/${workDir.name}" : "${workDir.name}"
 params.outdir = "${workDir.scheme}://${workdir}/synstage/"
 params.outdir_clean = params.outdir.replaceAll('/$', '')
 params.input_parent_dir = input_file.parent


### PR DESCRIPTION
# **Problem:**

There's been an issue with the building of `outdir_clean` that was preventing successful runs of `SYNSTAGE`. See this error as an example. There are extra fwd-slashes causing the pipeline run to fail.

<img width="567" height="257" alt="image" src="https://github.com/user-attachments/assets/77680d7d-a7d8-48c0-9f78-8b23aa0363e5" />

# **Solution:**

Removal of trailing slashes was part of the cleanup of `outdir`, but double-slashes and leading slashes (which is what caused the triple-slash after `workDir.scheme`) were not cleaned up before assigning the `outdir_clean` variable, which is what's used to build the `upload_location` string in `stage_file.nf` (which is where the problem occurs).

- [x] Fix leading slash(es) before assigning `outdir_clean`
- [x] Fix double slash(es) before assigning `outdir_clean`

# **Testing:**

A new SYNSTAGE workflow run of `demo.py` from the `py-orca` repository was launched, pointing at the revision in this branch, and was a success:

https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2g1z7VsIyhdbYE

<img width="576" height="689" alt="image" src="https://github.com/user-attachments/assets/a6f61c6c-b576-42ef-9f7b-130d9165c97a" />

And the file is stored in the expected location:

<img width="979" height="412" alt="image" src="https://github.com/user-attachments/assets/55399989-eca5-4cc3-8a14-721c1d968cde" />
