### PR TITLE
[DPE-1526] Implement a robust URI cleaning process for SYNSTAGE's `outdir` parameter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+# .github/workflows/tests.yml
+name: nextflow-tests
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    types: [opened, reopened]
+    paths-ignore:
+      - '**.md'
+
+env:
+  NXF_VER: "24.10.9"
+
+jobs:
+  utils-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      # Installs Nextflow and caches its download + plugins.
+      - name: Set up Nextflow
+        uses: nf-core/setup-nextflow@v2
+
+      - name: Run Utils unit tests
+        run: |
+          nextflow -version
+          nextflow run tests/test_utils.nf -lib ./lib -ansi-log false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,20 @@ Using the [Tower CLI](https://help.tower.nf/latest/cli/), or the [Seqera Platfor
 
 After you have tested your workflow, be sure to test any other workflows that depend on the modules you have modified. This will help ensure that the changes you made do not have any unintended side effects.
 
+## Running Unit Tests
+
+We have a [Github CI/CD test workflow](/.github/workflows/tests.yml) that will run automatically unit tests in the `tests/` directory as you are developing and pushing changes upstream.
+
+If you want to run the tests **locally**, follow [official Nextflow instructions to setup Nextflow and Java locally on your computer](https://www.nextflow.io/docs/latest/install.html).
+
+Then run the following in your terminal/session:
+
+```bash
+nextflow run tests/<test_script_name> -lib ./lib
+```
+
+
+
 ## Update The README
 
 Before submitting your pull request, update the `README.md` file to include a description of your workflow. Follow the example set by the `SYNSTAGE` and `SYNINDEX` sections and include all relavent information including a mermaid diagram describing the flow of data through the workflow.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Check out the [Quickstart](#Quickstart:SYNSTAGE) section for example parameter v
 
 - **`entry`**: (Required) The name of the workflow to run (`synstage`). This should be the name of the workflow file in the `workflows/` directory.
 - **`input`**: (Required) A text file containing Synapse URIs (_e.g._ `syn://syn28521174`). The text file can have any format (_e.g._ a single column of Synapse URIs, a CSV/TSV sample sheet for an nf-core workflow).
-- **`outdir`**: (Optional) An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix for Nextflow Tower runs (_e.g._ `s3://bucket_name/path/to/file`). If not provided, this will default to the parent directory of the input file.
+- **`outdir`**: (Optional) An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix for Nextflow Tower runs (_e.g._ `s3://bucket_name/path/to/file`). If not provided, this will default to the work directory of your machine if running locally, or a subdirectory called `systage` within the work directory of the Seqera Platform workspace in which your workflow will run (e.g. `s3://<bucket>/synstage/<path-to-file-based-on-save-strategy-parameter>`).
 - **`save_strategy`**: (Optional) A string indicating where to stage the files within the `outdir`. Options include:
     - `id_folders`: Files will be staged in child folders named after the Synapse or Seven Bridges ID of the file. This is the default behavior.
     - `flat`: Files will be staged in top level of the `outdir`.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Check out the [Quickstart](#Quickstart:SYNSTAGE) section for example parameter v
 
 - **`entry`**: (Required) The name of the workflow to run (`synstage`). This should be the name of the workflow file in the `workflows/` directory.
 - **`input`**: (Required) A text file containing Synapse URIs (_e.g._ `syn://syn28521174`). The text file can have any format (_e.g._ a single column of Synapse URIs, a CSV/TSV sample sheet for an nf-core workflow).
-- **`outdir`**: (Optional) An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix for Nextflow Tower runs. If not provided, this will default to the parent directory of the input file.
+- **`outdir`**: (Optional) An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix for Nextflow Tower runs (_e.g._ `s3://bucket_name/path/to/file`). If not provided, this will default to the parent directory of the input file.
 - **`save_strategy`**: (Optional) A string indicating where to stage the files within the `outdir`. Options include:
     - `id_folders`: Files will be staged in child folders named after the Synapse or Seven Bridges ID of the file. This is the default behavior.
     - `flat`: Files will be staged in top level of the `outdir`.

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -12,10 +12,6 @@ class Utils {
             throw new Exception("There must be a scheme in the URI (e.g., s3://)")
         }
 
-        if (!uri.authority && !uri.path) {
-            throw new Exception("URI must have either authority or path (e.g., s3://<authority>/<path> or s3:///<path>)")
-        }
-
         // Combine authority and path based on URI structure
         def fullPath
         if (uri.authority) {

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -22,7 +22,7 @@ class Utils {
 
     static public def get_publish_dir(params, file_id) {
         def strategy_map = [
-            "id_folders": { Paths.get(params.outdir_clean).resolve(file_id).toString() },
+            "id_folders": { "${params.outdir_clean}/${file_id}" },
             "flat": { "${params.outdir_clean}" }
             // Add more strategies as needed: "another_strategy": { "path_for_another_strategy" }
         ]

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -7,17 +7,27 @@ class Utils {
         // Use URI parsing to clean up redundant slashes while preserving all URI components
         def uri = new URI(outdir)
 
-        // Clean up the path by removing duplicate slashes and trailing slash
-        def cleanPath = (uri.path ?: '').replaceAll('/+', '/').replaceAll('/$', '')
-
-        // Build clean URI based on whether it has authority (bucket name) or not
-        if (uri.authority) {
-            // Example: s3://bucket/path (bucket is authority, path is path)
-            return "${uri.scheme}://${uri.authority}${cleanPath.startsWith('/') ? cleanPath : '/' + cleanPath}"
-        } else {
-            // Example: s3:///bucket/path (bucket is part of path, no authority)
-            return "${uri.scheme}://${cleanPath.replaceAll('^/', '')}"
+        // First ensure we have the required URI components
+        if (!uri.scheme) {
+            throw new Exception("There must be a scheme in the URI (e.g., s3://")
         }
+
+        if (!uri.authority && !uri.path) {
+            throw new Exception("URI must have either authority or path (e.g., s3://<authority>/<path> or s3:///<path>)")
+        }
+
+        // Combine authority and path based on URI structure
+        def fullPath
+        if (uri.authority) {
+            fullPath = uri.authority + (uri.path ?: '')
+        } else {
+            fullPath = uri.path ?: ''
+        }
+
+        // Remove leading, trailing, and duplicate slashes from fullPath before returning
+        def normalizedPath = fullPath.replaceAll('^/+', '').replaceAll('/+', '/').replaceAll('/+$', '')
+
+        return "${uri.scheme}://${normalizedPath}"
     }
 
     static public def get_publish_dir(params, file_id) {

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -9,7 +9,7 @@ class Utils {
 
         // First ensure we have the required URI components
         if (!uri.scheme) {
-            throw new Exception("There must be a scheme in the URI (e.g., s3://")
+            throw new Exception("There must be a scheme in the URI (e.g., s3://)")
         }
 
         if (!uri.authority && !uri.path) {

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -1,9 +1,28 @@
 // groovy_utils.groovy
 
+import java.nio.file.Paths
+
 class Utils {
+    static public def clean_uri(outdir) {
+        // Use URI parsing to clean up redundant slashes while preserving all URI components
+        def uri = new URI(outdir)
+
+        // Clean up the path by removing duplicate slashes and trailing slash
+        def cleanPath = (uri.path ?: '').replaceAll('/+', '/').replaceAll('/$', '')
+
+        // Build clean URI based on whether it has authority (bucket name) or not
+        if (uri.authority) {
+            // Example: s3://bucket/path (bucket is authority, path is path)
+            return "${uri.scheme}://${uri.authority}${cleanPath.startsWith('/') ? cleanPath : '/' + cleanPath}"
+        } else {
+            // Example: s3:///bucket/path (bucket is part of path, no authority)
+            return "${uri.scheme}://${cleanPath.replaceAll('^/', '')}"
+        }
+    }
+
     static public def get_publish_dir(params, file_id) {
         def strategy_map = [
-            "id_folders": { "${params.outdir_clean}/${file_id}" },
+            "id_folders": { Paths.get(params.outdir_clean).resolve(file_id).toString() },
             "flat": { "${params.outdir_clean}" }
             // Add more strategies as needed: "another_strategy": { "path_for_another_strategy" }
         ]

--- a/tests/test_utils.nf
+++ b/tests/test_utils.nf
@@ -1,0 +1,113 @@
+/*
+unit tests for Utils.groovy - no package dependencies
+*/
+
+nextflow.enable.dsl = 2
+
+workflow {
+
+  def failures = []
+
+  def check = { String name, Closure test ->
+    try {
+      test.call()
+      println "✅ ${name}"
+    }
+    catch (Throwable e) {
+      println "❌ ${name} — ${e.class.simpleName}: ${e.message}"
+      failures << [name: name, error: e]
+    }
+  }
+
+  // ----------------------------
+  // S3 scheme + bucket/path
+  // ----------------------------
+  check("clean_uri: preserves bucket/path and strips trailing slash") {
+    def got = Utils.clean_uri('s3://example-bucket/some_test_dir/')
+    assert got == 's3://example-bucket/some_test_dir' : "got=${got}"
+  }
+
+  check("clean_uri: removes duplicate + trailing slashes") {
+    def got = Utils.clean_uri('s3://example-bucket//some_test_dir///')
+    assert got == 's3://example-bucket/some_test_dir' : "got=${got}"
+  }
+
+  check("clean_uri: normalizes internal duplicate slashes") {
+    def got = Utils.clean_uri('s3://example-bucket/a//b///c/')
+    assert got == 's3://example-bucket/a/b/c' : "got=${got}"
+  }
+
+  // ----------------------------
+  // S3 scheme + path (this is how the default outdir is formed)
+  // ----------------------------
+  check("clean_uri: converts s3:///path to s3://bucket/path") {
+    def got = Utils.clean_uri('s3:///example-bucket/some_test_dir/')
+    assert got == 's3://example-bucket/some_test_dir' : "got=${got}"
+  }
+
+  // ----------------------------
+  // Bucket-only forms
+  // ----------------------------
+  check("clean_uri: bucket-only (no trailing slash)") {
+    def got = Utils.clean_uri('s3://example-bucket')
+    assert got == 's3://example-bucket' : "got=${got}"
+  }
+
+  check("clean_uri: bucket-only (with trailing slash)") {
+    def got = Utils.clean_uri('s3://example-bucket/')
+    assert got == 's3://example-bucket' : "got=${got}"
+  }
+
+  // ----------------------------
+  // file:// URI (authority is null)
+  // ----------------------------
+  check("clean_uri: file URI normalization (authority is null)") {
+    def got = Utils.clean_uri('file:///tmp//some_dir///')
+    assert got == 'file://tmp/some_dir' : "got=${got}"
+  }
+
+  check("clean_uri: s3 URI normalization (authority is null)") {
+    def got = Utils.clean_uri('s3:///home/ec2-user/nf-synapse/work/synstage/')
+    assert got == 's3://home/ec2-user/nf-synapse/work/synstage' : "got=${got}"
+  }
+
+  // --------------------------------------
+  // Missing scheme should throw exception
+  // --------------------------------------
+  check("clean_uri: throws if scheme missing, outdir = /<authority>/<path>") {
+    boolean threw = false
+    try {
+      Utils.clean_uri('/tmp/some_dir')
+    } catch (Exception e) {
+      threw = true
+      assert e.message.contains('There must be a scheme') : "msg=${e.message}"
+    }
+    assert threw : "Expected exception for missing scheme"
+  }
+
+  check("clean_uri: throws if authority or path missing, outdir = s3://") {
+    boolean threw = false
+    try {
+      Utils.clean_uri('s3://')
+    } catch (Exception e) {
+      threw = true
+      assert e.message.contains('Expected authority at index 5') : "msg=${e.message}"
+    }
+    assert threw : "Expected exception for missing authority or path"
+  }
+
+
+  // ----------------------------
+  // Summary / exit
+  // ----------------------------
+  if (failures) {
+    println "\n========== TEST SUMMARY =========="
+    println "Total: ${failures.size()} failed\n"
+    failures.eachWithIndex { f, i ->
+      println "${i + 1}) ${f.name}"
+    }
+    error "Utils tests failed (${failures.size()})."
+  } else {
+    println "\n✅ All Utils tests passed"
+  }
+}

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -14,12 +14,6 @@ params.outdir = "${workDir.scheme}://${workDir.resolve('synstage')}"
 // Clean up the output directory URI
 params.outdir_clean = Utils.clean_uri(params.outdir)
 
-// TODO: Debug logging to understand how the default build of outdir was ever able to work - remove later
-log.info "params.input: ${params.input}"
-log.info "params.outdir: ${params.outdir}"
-log.info "params.outdir_clean: ${params.outdir_clean}"
-log.info "workDir: ${workDir}"
-
 params.input_parent_dir = input_file.parent
 params.save_strategy = "id_folders"
 // Parse Synapse URIs from input file

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -19,6 +19,13 @@ normalized_path = uri.path.replaceAll('^/', '').replaceAll('/+', '/').replaceAll
 // Compose the final cleaned up outdir
 params.outdir_clean = "${uri.scheme}://${normalized_path}"
 
+// TODO: Debug logging to understand how the default build of outdir was ever able to work - remove later
+log.info "params.input: ${params.input}"
+log.info "params.outdir: ${params.outdir}"
+log.info "uri.path: ${uri.path}"
+log.info "uri.authority: ${uri.authority}"
+log.info "params.outdir_clean: ${params.outdir_clean}"
+
 params.input_parent_dir = input_file.parent
 params.save_strategy = "id_folders"
 // Parse Synapse URIs from input file

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -7,24 +7,20 @@ nextflow.enable.dsl = 2
 ========================================================================================
 */
 // Need default file or SYNINDEX cannot be run
-params.input = "${projectDir}/dummy.txt"
+params.input = projectDir.resolve('dummy.txt')
 input_file = file(params.input)
-workdir = "${workDir.parent}/${workDir.name}"
-params.outdir = "${workDir.scheme}://${workdir}/synstage/"
+// TODO: Can't we just use workDir? (check logs)
+workdir = workDir.parent.resolve(workDir.name)
+params.outdir = "${workDir.scheme}://${workdir.resolve('synstage')}"
 
-// Use URI parsing to clean up redundant slashes safely from path
-uri = new URI(params.outdir)
-// Remove leading slash, duplicate slashes, and trailing slash, in that order!
-normalized_path = uri.path.replaceAll('^/', '').replaceAll('/+', '/').replaceAll('/$', '')
-// Compose the final cleaned up outdir
-params.outdir_clean = "${uri.scheme}://${normalized_path}"
+// Clean up the output directory URI
+params.outdir_clean = Utils.clean_uri(params.outdir)
 
 // TODO: Debug logging to understand how the default build of outdir was ever able to work - remove later
 log.info "params.input: ${params.input}"
 log.info "params.outdir: ${params.outdir}"
-log.info "uri.path: ${uri.path}"
-log.info "uri.authority: ${uri.authority}"
 log.info "params.outdir_clean: ${params.outdir_clean}"
+log.info "workDir: ${workDir}"
 
 params.input_parent_dir = input_file.parent
 params.save_strategy = "id_folders"

--- a/workflows/synstage.nf
+++ b/workflows/synstage.nf
@@ -9,9 +9,7 @@ nextflow.enable.dsl = 2
 // Need default file or SYNINDEX cannot be run
 params.input = projectDir.resolve('dummy.txt')
 input_file = file(params.input)
-// TODO: Can't we just use workDir? (check logs)
-workdir = workDir.parent.resolve(workDir.name)
-params.outdir = "${workDir.scheme}://${workdir.resolve('synstage')}"
+params.outdir = "${workDir.scheme}://${workDir.resolve('synstage')}"
 
 // Clean up the output directory URI
 params.outdir_clean = Utils.clean_uri(params.outdir)


### PR DESCRIPTION
# **Problem:**

Issue raised [here](https://sagebionetworks.slack.com/archives/C048RL0RY74/p1765903284465309) & notes from investigation are found [here](https://sagebionetworks.jira.com/browse/DPE-1526?focusedCommentId=279774).

The `outdir_clean` parameter is built on the assumption that the URI provided (either the default `outdir` or an `outdir` provided by the user) is formatted such that there is NO URI authority, and only a URI scheme and path. See the _Execution Log_ of this [workflow run](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/3hl6mtL3klDQHD) for why the original path configuration was able to work for default paths. **Long story short, when the workflow uses the default `outdir` parameter, this `outdir` is built off the `workDir` of your Seqera Platform workspace, which seems to have a leading `/`. The extra `/` after `s3://` omits a URI authority, and treats the bucket name as part of the path.**

Results from the example workflow run, which uses the default `outdir` built off `workDir`:
```
params.input: s3://example-dev-project-tower-scratch/work/my_test_dataset.csv
params.outdir: s3:///example-dev-project-tower-scratch//work/synstage/
uri.path: /example-dev-project-tower-scratch//work/synstage/
uri.authority: null
params.outdir_clean: s3://example-dev-project-tower-scratch/work/synstage
```

When users provide an `outdir` themselves, likely in the format `s3://<bucket>/<path>` this leads to the following chain of issues:
1. **On `synstage.nf`**: The `outdir_clean` is incorrectly built without using the URI authority (`<bucket>`)
2. **On `stage_file.nf`**: The `Utils.get_publish_dir` creates an incorrect `upload_location` off that `outdir_clean` parameter
3. **On `stage_file.nf`**: The AWS CLI command to copy the file from local (EC2 instance) -> to S3 is using an incorrect S3 URI, and therefore cannot place the file(s) in the appropriate location

Separately, there are a lot of instances where `/` are added manually instead of programmatically, which adds confusion to the code and makes it more error-prone.

# **Solution:**

- [x] Rebuild `outdir_clean` in a way that handles multiple different formatting cases, so that no part of the original URI is left out (scheme, authority, path).
- [x] Remove manual path concatenation where possible

# **Testing:**

For each **Result**:
1) We check that the workflow ran successfully with the correct `outdir_clean`
2) We check that the samplesheet's files were stored in the correct location on S3

---

**Case 1**: Default `outdir` = `s3:///<path>`
**Result 1**: ✅ [link](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/AyFK41012f3i8)
<img width="613" height="208" alt="image" src="https://github.com/user-attachments/assets/69e5f7f1-00c1-449b-b871-a8d2845a631f" />
<img width="872" height="407" alt="image" src="https://github.com/user-attachments/assets/9cda5cd1-0979-4bd9-9e6c-e0a69a4a7e18" />


---

**Case 2**: User-provided `outdir` = `s3://<authority>/<path>/`
**Result 2**: ✅ [link](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/g2DvnXUvtH967)
<img width="620" height="223" alt="image" src="https://github.com/user-attachments/assets/1af906c2-f50d-4f81-a8eb-afaede167163" />
<img width="1026" height="727" alt="image" src="https://github.com/user-attachments/assets/0fdf744e-2193-4947-9d0e-6c091332850c" />

---

**Case 3**: User-provided `outdir` = `s3://<authority>/<path_level1>/<path_level2>`
**Result 3**: ✅ ([link](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/5s72oBWk3tM6jh))
<img width="623" height="223" alt="image" src="https://github.com/user-attachments/assets/53added2-e8a7-4d6a-a914-9aa086afc4ac" />
<img width="786" height="445" alt="image" src="https://github.com/user-attachments/assets/526e8c10-d447-4822-b695-3d0183624055" />

---

**Case 4**: User-provided `outdir` = `s3://<authority>/<path_level1>//<path_level2>//`
**Result 4**: ✅ ([link](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/15tzSX6FPEoxt5))
<img width="617" height="223" alt="image" src="https://github.com/user-attachments/assets/73a9244d-b3d8-447f-89e2-e967c5b93621" />
<img width="755" height="430" alt="image" src="https://github.com/user-attachments/assets/d8af1547-5ba2-43dc-80b6-6dac418649a9" />

---

**Case 5**: User-provided `outdir` = `s3://<authority>/.`
**Result 5**: ✅ ([link](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/6w5FPXVX9AIiA))
<img width="635" height="219" alt="image" src="https://github.com/user-attachments/assets/f52bef19-f1d4-4a2b-9a5d-5ee14719b471" />
<img width="701" height="443" alt="image" src="https://github.com/user-attachments/assets/98ac55bb-3a4c-4ee5-bc72-8788ee5c8eac" />

---

**Case 6** (Error): User-provided `outdir` = `/<authority>/<path>`
**Result 6**: ✅ ([link](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/3AwU3bsLP5PQeo))
This should throw an error because there is no scheme in the URI

---

**Case 7** (Error): User-provided `outdir` = `s3://`
**Result 7**: ✅ ([link](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/3OAuxwDPE8B0AP))
This should throw an error because there is no authority or path in the URI

