### PR TITLE
[DPE-1746] Add mapping of indexed synapse entities to S3 uris

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
           nextflow run tests/test_utils.nf -lib ./lib -ansi-log false
 
       - name: Run python unit tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/bin
         run: |
           pip install pytest
           pytest tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,3 +35,8 @@ jobs:
         run: |
           nextflow -version
           nextflow run tests/test_utils.nf -lib ./lib -ansi-log false
+
+      - name: Run python unit tests
+        run: |
+          pip install pytest
+          pytest tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,10 +35,26 @@ jobs:
         run: |
           nextflow -version
           nextflow run tests/test_utils.nf -lib ./lib -ansi-log false
+      
+  python-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.10]
 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}  
+        uses: actions/setup-python@v4  
+        with:  
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies  
+        run: |  
+          python -m pip install --upgrade pip
+          pip install pytest==7.4.2
       - name: Run python unit tests
-        env:
-          PYTHONPATH: ${{ github.workspace }}/bin
         run: |
-          pip install pytest
-          pytest tests
+          PYTHONPATH=src python -m pytest tests/ -v --tb=short

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies  
         run: |  
           python -m pip install --upgrade pip
-          pip install pytest==7.4.2
+          pip install pytest==7.4.2 synapseclient==4.8
       - name: Run python unit tests
         run: |
           PYTHONPATH=src python -m pytest tests/ -v --tb=short

--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 A centralized repository of Nextflow workflows that interact with [Synapse](https://www.synapse.org/).
 
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Structure](#structure)
+- [Usage](#usage)
+- [Meta-Usage](#meta-usage)
+- [Authentication](#authentication)
+  - [Synapse](#synapse)
+  - [Profiles](#profiles)
+- [Included Workflows](#included-workflows)
+  - [`SYNSTAGE`: Stage Synapse Files To AWS S3](#synstage-stage-synapse-files-to-aws-s3)
+    - [Purpose](#purpose-1)
+    - [Overview](#overview)
+    - [Workflow Diagram](#workflow-diagram)
+    - [Quickstart: SYNSTAGE](#quickstart-synstage)
+    - [Special Considerations for Staging Seven Bridges Files](#special-considerations-for-staging-seven-bridges-files)
+    - [Parameters](#parameters)
+    - [Known Limitations](#known-limitations)
+  - [`SYNINDEX`: Index S3 Objects Into Synapse](#synindex-index-s3-objects-into-synapse)
+    - [Purpose](#purpose-2)
+    - [Overview](#overview-1)
+    - [Workflow Diagram](#workflow-diagram-1)
+    - [Quickstart: SYNINDEX](#quickstart-synindex)
+    - [Outputs](#outputs)
+    - [Parameters](#parameters-1)
+    - [Known Limitations](#known-limitations-1)
+
 ## Purpose
 
 The purpose of this repository is to provide a collection of Nextflow workflows that interact with Synapse by leveraging the [Synapse Python Client](https://python-docs.synapse.org/en/stable/). These workflows are intended to be used in a [Seqera Platform](https://docs.seqera.io/platform/latest/) environment primarily, but they can also be executed using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run) on your local machine.
@@ -197,6 +224,37 @@ The examples below demonstrate how you would index files from an S3 bucket calle
     ```
 
 1. Retrieve the output file, which by default is stored in `S3://example-bucket/synindex/under-syn12345678/` in our example. This folder will contain a mapping of Synapse URIs to their indexed Synapse IDs.
+
+### Outputs
+
+`SYNINDEX` writes `output.csv` to `${s3_prefix}/synindex/under-${parent_id}/` (`s3://example-bucket/synindex/under-syn12345678/output.csv` in the example above). It is a CSV with one row per indexed file, intended to be consumed by downstream processes such as provenance tracking containing the following metadata:
+
+| Column | Description |
+| --- | --- |
+| `object_uri` | S3 URI of the source object |
+| `synapse_id` | Synapse ID of the File entity the object was indexed as |
+| `parent_id` | Synapse ID of the folder (or project) the File was created in |
+| `file_handle_id` | ID of the external S3 file handle backing the File |
+| `content_md5` | MD5 checksum of the object |
+| `file_name` | Name of the File entity |
+
+**Example:**
+
+| object_uri                                   | synapse_id | parent_id     | file_handle_id | content_md5                        | file_name   |
+| -------------------------------------------- | ---------- | ------------- | -------------: | ---------------------------------- | ----------- |
+| `s3://example-bucket/test.txt`               | `syn111`   | `syn12345678` |         `7788` | `d41d8cd98f00b204e9800998ecf8427e` | `test.txt`  |
+| `s3://example-bucket/child_folder/test1.txt` | `syn112`   | `syn22222222` |         `7789` | `e99a18c428cb38d5f260853678922e03` | `test1.txt` |
+
+**NOTE** It's recommended to read the file with a real CSV parser rather than splitting on commas AND look rows up by `object_uri`. For example, in Python:
+
+```python
+import csv
+
+with open("output.csv") as infile:
+    uri_to_synapse_id = {
+        row["object_uri"]: row["synapse_id"] for row in csv.DictReader(infile)
+    }
+```
 
 ### Parameters
 

--- a/bin/synapse_index.py
+++ b/bin/synapse_index.py
@@ -4,6 +4,7 @@ import csv
 import os
 import re
 import sys
+from typing import Dict
 
 import synapseclient
 from synapseclient.models import File
@@ -67,7 +68,7 @@ def create_file_handle(
     return file_handle["id"]
 
 
-def write_mapping(mapping_file: str, row: dict) -> None:
+def write_mapping(mapping_file: str, row: Dict[str, str]) -> None:
     """Writes the S3 URI to Synapse ID mapping for a single indexed file.
 
     Arguments:

--- a/bin/synapse_index.py
+++ b/bin/synapse_index.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import csv
 import os
 import re
 import sys
@@ -7,6 +8,19 @@ import sys
 import synapseclient
 from synapseclient.models import File
 from synapseclient.core.utils import md5_for_file_hex
+
+# Per-file mapping row emitted by this script. SYNINDEX concatenates these rows
+# into a single `output.csv` so that downstream processes can resolve an S3 URI
+# to the Synapse entity it was indexed as.
+MAPPING_FILE = "file_info.csv"
+MAPPING_FIELDS = [
+    "object_uri",
+    "synapse_id",
+    "parent_id",
+    "file_handle_id",
+    "content_md5",
+    "file_name",
+]
 
 
 def clean_file_name(file_path: str) -> str:
@@ -53,6 +67,19 @@ def create_file_handle(
     return file_handle["id"]
 
 
+def write_mapping(mapping_file: str, row: dict) -> None:
+    """Writes the S3 URI to Synapse ID mapping for a single indexed file.
+
+    Arguments:
+        mapping_file: Path of the CSV file to write.
+        row: Mapping values keyed by the names in MAPPING_FIELDS.
+    """
+    with open(mapping_file, "w", newline="") as outfile:
+        writer = csv.DictWriter(outfile, fieldnames=MAPPING_FIELDS)
+        writer.writeheader()
+        writer.writerow(row)
+
+
 if __name__ == "__main__":
     storage_id = sys.argv[1]
     file_path = sys.argv[2]
@@ -78,4 +105,14 @@ if __name__ == "__main__":
         data_file_handle_id=file_handle_id,
         content_md5=md5_checksum,
     ).store()
-    print(f"{uri},{file.id}", end="")
+    write_mapping(
+        mapping_file=MAPPING_FILE,
+        row={
+            "object_uri": uri,
+            "synapse_id": file.id,
+            "parent_id": parent_id,
+            "file_handle_id": file_handle_id,
+            "content_md5": md5_checksum,
+            "file_name": file_name,
+        },
+    )

--- a/modules/synapse_index.nf
+++ b/modules/synapse_index.nf
@@ -10,11 +10,11 @@ process SYNAPSE_INDEX {
   val   storage_id
 
   output:
-  env file_info
+  path 'file_info.csv'
 
   script:
   """
-  file_info=\$(synapse_index.py ${storage_id} ${object} '${uri}' ${parent_id})
+  synapse_index.py ${storage_id} ${object} '${uri}' ${parent_id}
   """
 
 }

--- a/modules/synapse_mirror.nf
+++ b/modules/synapse_mirror.nf
@@ -5,15 +5,13 @@ process SYNAPSE_MIRROR {
 
   secret 'SYNAPSE_AUTH_TOKEN'
 
-  publishDir "${publish_dir}", mode: 'copy'
-  
-
   input:
   path  objects
   val   s3_prefix
   val   parent_id
-  val   publish_dir
 
+  // Internal hand-off to SYNAPSE_INDEX only; the published mapping of this
+  // workflow is `output.csv`, which carries these columns plus the Synapse IDs.
   output:
   path  'parent_ids.csv'
 

--- a/tests/test_synapse_index.py
+++ b/tests/test_synapse_index.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from synapse_index import (
+from bin.synapse_index import (
     MAPPING_FIELDS,
     clean_file_name,
     create_file_handle,

--- a/tests/test_synapse_index.py
+++ b/tests/test_synapse_index.py
@@ -1,0 +1,174 @@
+# tests/test_synapse_index.py
+
+import csv
+from unittest.mock import MagicMock
+
+import pytest
+
+from synapse_index import (
+    MAPPING_FIELDS,
+    clean_file_name,
+    create_file_handle,
+    write_mapping,
+)
+
+
+class TestCleanFileName:
+    def test_returns_basename(self) -> None:
+        result = clean_file_name("/some/path/to/file.txt")
+
+        assert result == "file.txt"
+
+    def test_replaces_special_characters_with_underscores(self) -> None:
+        result = clean_file_name("/some/path/file@name#test!.txt")
+
+        assert result == "file_name_test_.txt"
+
+    def test_preserves_allowed_characters(self) -> None:
+        result = clean_file_name(
+            "/some/path/file name_1+test'(abc)-data.csv"
+        )
+
+        assert result == "file name_1+test'(abc)-data.csv"
+
+    def test_replaces_path_filename_special_characters_only(self) -> None:
+        result = clean_file_name(
+            "/directory-with@special/chars/data:file.csv"
+        )
+
+        assert result == "data_file.csv"
+
+
+class TestCreateFileHandle:
+    def test_creates_external_s3_file_handle(self) -> None:
+        syn = MagicMock()
+        syn.create_external_s3_file_handle.return_value = {
+            "id": "12345"
+        }
+
+        result = create_file_handle(
+            syn=syn,
+            storage_id="6789",
+            uri="s3://example-bucket/path/to/file.txt",
+            file_name="file.txt",
+            md5_checksum="abc123",
+        )
+
+        assert result == "12345"
+
+        syn.create_external_s3_file_handle.assert_called_once_with(
+            bucket_name="example-bucket",
+            s3_file_key="path/to/file.txt",
+            file_path="file.txt",
+            storage_location_id="6789",
+            md5="abc123",
+        )
+
+    def test_preserves_nested_s3_key(self) -> None:
+        syn = MagicMock()
+        syn.create_external_s3_file_handle.return_value = {
+            "id": "12345"
+        }
+
+        create_file_handle(
+            syn=syn,
+            storage_id="6789",
+            uri="s3://example-bucket/a/b/c/file.txt",
+            file_name="file.txt",
+            md5_checksum="abc123",
+        )
+
+        syn.create_external_s3_file_handle.assert_called_once_with(
+            bucket_name="example-bucket",
+            s3_file_key="a/b/c/file.txt",
+            file_path="file.txt",
+            storage_location_id="6789",
+            md5="abc123",
+        )
+
+    def test_invalid_s3_uri_raises_error(self) -> None:
+        syn = MagicMock()
+
+        with pytest.raises(AttributeError):
+            create_file_handle(
+                syn=syn,
+                storage_id="6789",
+                uri="https://example.com/file.txt",
+                file_name="file.txt",
+                md5_checksum="abc123",
+            )
+
+        syn.create_external_s3_file_handle.assert_not_called()
+
+
+class TestWriteMapping:
+    def test_writes_expected_csv(self, tmp_path) -> None:
+        mapping_file = tmp_path / "file_info.csv"
+
+        row = {
+            "object_uri": "s3://example-bucket/test.txt",
+            "synapse_id": "syn111",
+            "parent_id": "syn12345678",
+            "file_handle_id": "7788",
+            "content_md5": "d41d8cd98f00b204e9800998ecf8427e",
+            "file_name": "test.txt",
+        }
+
+        write_mapping(
+            mapping_file=str(mapping_file),
+            row=row,
+        )
+
+        with mapping_file.open(newline="") as infile:
+            reader = csv.DictReader(infile)
+            rows = list(reader)
+
+        assert reader.fieldnames == MAPPING_FIELDS
+        assert rows == [row]
+
+    def test_overwrites_existing_mapping_file(self, tmp_path) -> None:
+        mapping_file = tmp_path / "file_info.csv"
+
+        mapping_file.write_text("old,data\nfoo,bar\n")
+
+        row = {
+            "object_uri": "s3://example-bucket/test.txt",
+            "synapse_id": "syn111",
+            "parent_id": "syn12345678",
+            "file_handle_id": "7788",
+            "content_md5": "abc123",
+            "file_name": "test.txt",
+        }
+
+        write_mapping(
+            mapping_file=str(mapping_file),
+            row=row,
+        )
+
+        with mapping_file.open(newline="") as infile:
+            reader = csv.DictReader(infile)
+            rows = list(reader)
+
+        assert reader.fieldnames == MAPPING_FIELDS
+        assert rows == [row]
+
+    def test_all_mapping_fields_are_written_in_expected_order(
+        self,
+        tmp_path,
+    ) -> None:
+        mapping_file = tmp_path / "file_info.csv"
+
+        row = {
+            "object_uri": "s3://bucket/file.txt",
+            "synapse_id": "syn1",
+            "parent_id": "syn2",
+            "file_handle_id": "3",
+            "content_md5": "abc",
+            "file_name": "file.txt",
+        }
+
+        write_mapping(str(mapping_file), row)
+
+        first_line = mapping_file.read_text().splitlines()[0]
+
+        assert first_line == ",".join(MAPPING_FIELDS)

--- a/workflows/synindex.nf
+++ b/workflows/synindex.nf
@@ -52,7 +52,7 @@ workflow SYNINDEX {
   UPDATE_OWNER(GET_USER_ID.output, s3_prefix)
   REGISTER_BUCKET(bucket, base_key, UPDATE_OWNER.output)
   LIST_OBJECTS(s3_prefix, bucket, params.filename_string)
-  SYNAPSE_MIRROR(LIST_OBJECTS.output, s3_prefix, params.parent_id, publish_dir)
+  SYNAPSE_MIRROR(LIST_OBJECTS.output, s3_prefix, params.parent_id)
   ch_parent_ids = SYNAPSE_MIRROR.output 
         .splitCsv(header:true) 
         .map { row -> tuple(row.object_uri, file(row.object_uri), row.folder_id) }

--- a/workflows/synindex.nf
+++ b/workflows/synindex.nf
@@ -57,6 +57,11 @@ workflow SYNINDEX {
         .splitCsv(header:true) 
         .map { row -> tuple(row.object_uri, file(row.object_uri), row.folder_id) }
   ch_file_ids = SYNAPSE_INDEX(ch_parent_ids, REGISTER_BUCKET.output)
-  ch_file_ids
-    .collectFile(name: "output.csv", storeDir: publish_dir, newLine: true)
+  // Concatenate the per-file rows into a single CSV mapping each S3 URI to the
+  // Synapse entity it was indexed as, keeping only one header row.
+  ch_mapping = ch_file_ids
+    .collectFile(name: "output.csv", storeDir: publish_dir, keepHeader: true, skip: 1, sort: true)
+
+  emit:
+  mapping = ch_mapping
 }


### PR DESCRIPTION
# **Problem:**
We don't have direct mapping what synapse ids the indexed synapse entities get saved to after `synindex` runs other than a print output (which I haven't seen appear on Seqera platform yet).

We currently do output a `synindex/parent_ids.csv` that gives us `object_uri`, `folder_id` in synapse_mirror.py

# **Solution:**
This PR will produce an `output.csv` file that maps the indexed synapse entities with their S3 location (that they got indexed from).

# **Testing:**
- Ran for the BDF POC Dags which were able to use the `output.csv` to produce simple provenance connecting the output files on synapse to their input FASTQ files